### PR TITLE
Feature/axios

### DIFF
--- a/src/components/HeaderLogin.tsx
+++ b/src/components/HeaderLogin.tsx
@@ -9,7 +9,7 @@ import Button from './Button';
 import { client } from '../services/axios';
 import { useAuthStore } from '../stores/authStore';
 import { useImageStore } from '../stores/imageStore';
-import prof from '../assets/imgs/기본 프로필.png';
+import prof from '../assets/imgs/defaultProfileImg.png';
 
 export default function HeaderLogin() {
   const navigate = useNavigate();

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -51,7 +51,7 @@ export default function UserList() {
                 alt={user.fullName}
                 className="mr-3 h-6 w-6 rounded-full border border-gray-200 object-cover"
               />
-              <span className="test-sm flex-1">{user.fullName}</span>
+              <span className="flex-1 text-sm">{user.fullName}</span>
             </li>
           ))}
         </ul>

--- a/src/pages/ChannelList.tsx
+++ b/src/pages/ChannelList.tsx
@@ -5,7 +5,6 @@ import type { Channel } from '../types/channel';
 import IsLoggedInModal from '../components/IsLoggedInModal';
 import { fetchChannels, deleteChannel } from '../services/channelApi';
 import { useAuthStore } from '../stores/authStore';
-import { setSubscribedChannels } from '../utils/localSubscribe';
 import CreateChannelForm from '../components/CreateChannelForm';
 import { FaTrashAlt } from 'react-icons/fa';
 import { createPortal } from 'react-dom';
@@ -14,6 +13,10 @@ import { channelData } from '../data/channelData';
 import { channelIndexMapping } from '../utils/channelIndexMapping';
 import { useSubscriptionStore } from '../stores/subscriptionStore';
 import { customToast } from '../utils/customToast';
+import {
+  subscribeChannel,
+  unsubscribeChannel,
+} from '../services/subscribeChannelApi';
 
 export default function ChannelList() {
   const navigate = useNavigate();
@@ -29,7 +32,7 @@ export default function ChannelList() {
 
   //구독 상태 전역 상태 관리
   const subscribes = useSubscriptionStore((state) => state.subscribes);
-  const setSubscribes = useSubscriptionStore((state) => state.setSubscribes);
+  const syncSubscribes = useSubscriptionStore((state) => state.syncSubscribes);
 
   //다중 클릭 방지
   const [subscribeLock, setSubscribeLock] = useState(false);
@@ -37,10 +40,10 @@ export default function ChannelList() {
 
   // 인덱스 매핑 테이블
   const [indexMapping, setIndexMapping] = useState<Record<string, number>>({});
-
   const [loading, setLoading] = useState(true);
 
-  const toggleSubscribe = (id: string) => {
+  //구독/구독취소 핸들러
+  const toggleSubscribe = async (id: string) => {
     if (!isLoggedIn) {
       setModalOpen(true);
       return;
@@ -48,20 +51,25 @@ export default function ChannelList() {
     if (subscribeLock) return;
     setSubscribeLock(true);
 
-    const updatedSubscribes = subscribes.includes(id)
-      ? subscribes.filter((sub) => sub !== id)
-      : [...subscribes, id];
-
-    setSubscribes(updatedSubscribes);
-    setSubscribedChannels(updatedSubscribes);
-    if (subscribes.includes(id)) {
-      customToast('구독이 취소되었습니다.', 'info');
-    } else {
-      customToast('채널을 구독하였습니다.', 'success');
+    try {
+      if (subscribes.includes(id)) {
+        await unsubscribeChannel(id);
+        customToast('구독이 취소되었습니다.', 'info');
+      } else {
+        await subscribeChannel(id);
+        customToast('구독되었습니다.', 'success');
+      }
+      await syncSubscribes(); //서버와 동기화
+    } catch (error) {
+      customToast('오류가 발생했습니다.', 'error');
+      console.error(error);
+    } finally {
+      if (subscribeTimeout.current) clearTimeout(subscribeTimeout.current);
+      subscribeTimeout.current = setTimeout(
+        () => setSubscribeLock(false),
+        1000,
+      );
     }
-
-    if (subscribeTimeout.current) clearTimeout(subscribeTimeout.current);
-    subscribeTimeout.current = setTimeout(() => setSubscribeLock(false), 1000);
   };
 
   const onClickDeleteBtn = (id: string) => {
@@ -106,6 +114,11 @@ export default function ChannelList() {
         const mapping = channelIndexMapping(channels);
         setIndexMapping(mapping);
 
+        //구독 상태 동기화
+        const { syncSubscribes } = useSubscriptionStore.getState();
+        await syncSubscribes();
+
+        //이미지 프리뷰 설정
         channels.forEach((channel) => {
           const matchedChannel = channelData.find(
             (c) => c.name === channel.name,

--- a/src/pages/ChannelList.tsx
+++ b/src/pages/ChannelList.tsx
@@ -57,7 +57,7 @@ export default function ChannelList() {
         customToast('구독이 취소되었습니다.', 'info');
       } else {
         await subscribeChannel(id);
-        customToast('구독되었습니다.', 'success');
+        customToast('채널을 구독하였습니다.', 'success');
       }
       await syncSubscribes(); //서버와 동기화
     } catch (error) {

--- a/src/pages/ChannelPage.tsx
+++ b/src/pages/ChannelPage.tsx
@@ -11,8 +11,11 @@ import { fetchChannels } from '../services/channelApi';
 import { Channel } from '../types/channel';
 import { getImagePreview } from '../utils/localImage';
 import { useSubscriptionStore } from '../stores/subscriptionStore';
-import { setSubscribedChannels } from '../utils/localSubscribe';
 import { customToast } from '../utils/customToast';
+import {
+  subscribeChannel,
+  unsubscribeChannel,
+} from '../services/subscribeChannelApi';
 
 export default function ChannelPage({ id }: { id: string }) {
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn); // 로그인 상태 확인
@@ -21,31 +24,33 @@ export default function ChannelPage({ id }: { id: string }) {
   const [isLoading, setIsLoading] = useState(true);
   const [subscribing, setSubscribing] = useState(false);
 
-  //구독 상태 전역 관리
+  //구독 상태 전역 관리 및 서버 동기화
   const subscribes = useSubscriptionStore((state) => state.subscribes);
-  const setSubscribes = useSubscriptionStore((state) => state.setSubscribes);
+  const syncSubscribes = useSubscriptionStore((state) => state.syncSubscribes);
 
   const channelId = channelData?._id ?? '';
   const isSubscribed = subscribes.includes(channelId);
 
-  const SubscribedHandler = () => {
+  const SubscribedHandler = async () => {
     if (subscribing) return; // 1초 동안 클릭 막음
     setSubscribing(true);
 
     // 구독/구독취소 로직
-    let updated;
-    if (isSubscribed) {
-      updated = subscribes.filter((subId) => subId !== channelId);
-      customToast('구독이 취소되었습니다.', 'info');
-    } else {
-      updated = [...subscribes, channelId];
-      customToast('채널을 구독하였습니다.', 'success');
+    try {
+      if (isSubscribed) {
+        await unsubscribeChannel(channelId);
+        customToast('구독이 취소되었습니다.', 'info');
+      } else {
+        await subscribeChannel(channelId);
+        customToast('채널을 구독하였습니다.', 'success');
+      }
+      await syncSubscribes(); // 서버와 동기화
+    } catch (error) {
+      customToast('오류가 발생했습니다.', 'error');
+      console.error(error);
+    } finally {
+      setTimeout(() => setSubscribing(false), 1000);
     }
-    setSubscribes(updated);
-    setSubscribedChannels(updated);
-
-    // 1초 뒤에 다시 클릭 가능
-    setTimeout(() => setSubscribing(false), 1000);
   };
 
   useEffect(() => {
@@ -61,6 +66,10 @@ export default function ChannelPage({ id }: { id: string }) {
         } else {
           console.error(`해당 인덱스 ${id}에 채널이 없습니다.`);
         }
+
+        //구독 상태 서버 동기화
+        const { syncSubscribes } = useSubscriptionStore.getState();
+        await syncSubscribes();
       } catch (err) {
         console.error('채널 불러오기 실패:', err);
       } finally {

--- a/src/services/UserAPI.ts
+++ b/src/services/UserAPI.ts
@@ -1,7 +1,14 @@
 import { client } from './axios';
 import { User } from '../types/user';
 
+//모든 유저 가져오기
 export const fetchUsers = async (): Promise<User[]> => {
   const { data } = await client.get('/users/get-users');
+  return data;
+};
+
+// 현재 로그인한 유저 정보 가져오기
+export const fetchCurrentUser = async (): Promise<User> => {
+  const { data } = await client.get<User>('/auth-user');
   return data;
 };

--- a/src/services/subscribeChannelApi.ts
+++ b/src/services/subscribeChannelApi.ts
@@ -1,0 +1,22 @@
+import { client } from './axios';
+import { Follow } from '../types/follow';
+
+//api의 user - follow/unfollow 를 채널 subscribe/unsubscribe로 사용
+export const subscribeChannel = async (channelId: string) => {
+  // userId 대신 채널ID를 넣어서 사용
+  await client.post('/follow/create', { userId: channelId });
+};
+
+export const unsubscribeChannel = async (channelId: string) => {
+  // followId는 팔로우(구독) 관계의 유저 _id
+  const { data: user } = await client.get('/auth-user');
+  const targetFollow = user.following.find(
+    (follow: Follow) => follow.user === channelId,
+  );
+
+  if (targetFollow) {
+    await client.delete('/follow/delete', {
+      data: { id: targetFollow._id },
+    });
+  }
+};

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { useSubscriptionStore } from './subscriptionStore';
 
 interface AuthStore {
   isLoggedIn: boolean;
@@ -17,8 +18,11 @@ export const useAuthStore = create<AuthStore>()(
       accessToken: null,
       login: (accessToken, isAdmin) =>
         set({ isLoggedIn: true, isAdmin, accessToken }),
-      logout: () =>
-        set({ isLoggedIn: false, isAdmin: false, accessToken: null }),
+      logout: () => {
+        set({ isLoggedIn: false, isAdmin: false, accessToken: null });
+        //구독 상태 초기화
+        useSubscriptionStore.getState().setSubscribes([]);
+      },
     }),
     {
       name: 'auth-storage', // sessionStorage 내 key 이름

--- a/src/stores/subscriptionStore.ts
+++ b/src/stores/subscriptionStore.ts
@@ -1,11 +1,18 @@
 import { create } from 'zustand';
+import { client } from '../services/axios';
+import { User } from '../types/user';
 
 interface SubscriptionState {
   subscribes: string[];
   setSubscribes: (subs: string[]) => void;
+  syncSubscribes: () => Promise<void>;
 }
 
 export const useSubscriptionStore = create<SubscriptionState>((set) => ({
   subscribes: [],
   setSubscribes: (subs) => set({ subscribes: subs }),
+  syncSubscribes: async () => {
+    const { data: user } = await client.get<User>('/auth-user');
+    set({ subscribes: user.following.map((follow) => follow.user) });
+  },
 }));

--- a/src/types/follow.d.ts
+++ b/src/types/follow.d.ts
@@ -1,0 +1,7 @@
+export type Follow = {
+  _id: string;
+  user: string; // 구독(팔로우) 대상의 ID (채널ID)
+  follower: string; // 나의 ID
+  createdAt: string;
+  updatedAt: string;
+};

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -1,3 +1,5 @@
+import { Follow } from './follow';
+
 export type User = {
   coverImage: string; // 커버 이미지
   image: string; // 프로필 이미지
@@ -9,7 +11,7 @@ export type User = {
   likes: Like[];
   comments: CommentType[];
   followers: [];
-  following: [];
+  following: Follow[];
   notifications: [];
   messages: [];
   _id: string;


### PR DESCRIPTION
## ✨ PR 개요

사용자의 채널 구독 정보를 서버에 저장하고 불러올 수 있습니다.

---

## 🛠️ 작업 상세 내용

이번 PR에서 수행한 작업 유형에 체크해 주세요.

- [x] New Feature (새 기능 추가)
- [ ] Bug Fix (버그 수정)
- [ ] Remove Feature (기능 제거)
- [x] Change Logic (로직 수정)
- [ ] Style (스타일 수정: 코드 포맷, CSS 등)
- [ ] Test (테스트 코드 추가/수정)
- [ ] Set up (환경 설정, 패키지 설정 등)

---

## 🔥 작업 내용 및 관련 이슈

- follow api 를 이용해서 팔로잉한 user_id를 저장하는 대신 channel_id를 저장합니다.
- zustand를 써서 전역으로 관리하여 sidebar, channel page, post page에 구독 정보를 공유합니다.
- 로컬 스토리지에서 api를 사용하여 관리하도록 변경하였습니다. (로컬 저장하는 함수는 아직 남겨 놨습니다.)

---

## 📜 새로 설치한 패키지 목록

---

## 📸 스크린샷 (선택)

- ![subscribe](https://github.com/user-attachments/assets/799e7128-c681-4ad0-adc7-6e71b3d64f4e)


---

## ✍️ 리뷰 시 참고 사항

- 홈에서 로그아웃을 하려면 캐로셀 아래에 로그아웃 모달이 묻히는 경우가 있는 것 같습니다. 
